### PR TITLE
changed dellin Document.id type to string

### DIFF
--- a/src/Service/Dellin/Model/Response/Order/Document.php
+++ b/src/Service/Dellin/Model/Response/Order/Document.php
@@ -29,9 +29,9 @@ use JMS\Serializer\Annotation as Serializer;
 class Document
 {
     /**
-     * @var int
+     * @var string
      *
-     * @Serializer\Type("integer")
+     * @Serializer\Type("string")
      * @Serializer\SerializedName("id")
      *
      * @FakeMockField(value="39513109")


### PR DESCRIPTION
В api ДЛ в ответе на getOrders в documents заказа могут приходить накладные, id у которых является строкой.

